### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,8 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num-traits = "0.2.15"
 serde = { version = "1.0", optional = true, features = ["derive"]}
+[dependencies.num-traits]
+version = "0.2.15"
+default-features = false
+# features = ["libm"]    # <--- Uncomment if you wish to use `Float` and `Real` without `std`


### PR DESCRIPTION
Removed default features from num-traits so it compiles for `#[no-std]`